### PR TITLE
Book List Template and Queryset

### DIFF
--- a/authorsite/templates/dark_footer.html
+++ b/authorsite/templates/dark_footer.html
@@ -12,8 +12,8 @@
             <a href="{% slugurl 'contact' %}" class="footer-link" target="__blank">
                 <i class="fa fa-envelope px-2 icon-big" aria-label="twitter-icon"></i></a>
         </div>
-        <div class="col text-right">
-            <a class="btn btn-muted px-1 py-1 newsletter-font orange-link" href="{% slugurl 'newsletter' %}" role="button">Sign Up For Newsletter</a>
+        <div class="col-auto text-center md-12 mx-auto">
+            <a class="btn btn-outline-warning p-2 newsletter-font text-uppercase" href="{% slugurl 'newsletter' %}" role="button">Get Newsletter</a>
         </div>
     </div>
 </div>

--- a/books/models.py
+++ b/books/models.py
@@ -146,18 +146,18 @@ class BookPage(Page):
         InlinePanel('book_reviews', label="Book Reviews"),
     ]
 
-class BooksIndexPage(Page, RoutablePageMixin, MenuPageMixin):
+class BooksIndexPage(Page, MenuPageMixin):
     intro = RichTextField(blank=True)
+
+    @route(r'^$', name='all') # override the default route
+    def all_books(self, request):
+        """View Function that shows all books."""
+        book_list = BookPage.objects.live()
+        return self.render(request, context_overrides={
+            'book_list': book_list,
+        })
+    
     content_panels = Page.content_panels + [
         FieldPanel('intro', classname="full"),
         menupage_panel,
     ]
-    @route(r'^$', name='all') # override the default route
-    def all_books(self, request):
-        """
-       View Function that shows all books.
-        """
-        book_list = BookPage.objects.live().order_by('-sort_order')
-        return self.render(request, context_overrides={
-            'book_list': book_list,
-        })

--- a/books/models.py
+++ b/books/models.py
@@ -146,16 +146,18 @@ class BookPage(Page):
         InlinePanel('book_reviews', label="Book Reviews"),
     ]
 
-class BooksIndexPage(Page, MenuPageMixin):
+class BooksIndexPage(Page, RoutablePageMixin, MenuPageMixin):
     intro = RichTextField(blank=True)
 
     @route(r'^$', name='all') # override the default route
     def all_books(self, request):
         """View Function that shows all books."""
-        book_list = BookPage.objects.live()
-        return self.render(request, context_overrides={
-            'book_list': book_list,
-        })
+        book_list = BookPage.objects.all()
+        return self.render(
+            request, 
+            context_overrides={
+                'book_list': book_list,
+            })
     
     content_panels = Page.content_panels + [
         FieldPanel('intro', classname="full"),

--- a/books/templates/books/books_index_page.html
+++ b/books/templates/books/books_index_page.html
@@ -1,38 +1,46 @@
 {% extends "base.html" %}
-
 {% load wagtailcore_tags wagtailimages_tags static%}
-
 {% block body_class %}template-homepage{% endblock %}
-
 {% block content %}
+
 <div class="container-fluid container-dark py-5">
     <div class="container">
-        <div class="row">
-            <h1 class="text-white">{{ page.title }}</h1>
+        <div class="row justify-content-center">
+            <div class="col text-center">
+                <h1 class="text-center display-4 mt-2 mb-4 text-warning">{{ page.title }}</h1>
+            </div>
         </div>
-        <div class="row">
-            <div class="intro text-white">{{ page.intro|richtext }}</div>
+        <div class="row justify-content-center">
+            <div class="col text-center">
+                <div class="intro text-muted h4">{{ page.intro|richtext }}</div>
+            </div>
         </div>
     </div>
-    <div class="container mt-3">
-        {% for book in book_list %}
-        <div class="row align-items-start">
-            <div class="col-lg-8 col-md-6 text-white bg-primary mt-3 mb-2">
-                <div class="card-body bg-primary">
-                    <h2 class="card-title text-white text-center"><a href="{% pageurl book %}" class="text-white">{{ book.book_title }}</a></h2>
-                </div>
+    {% for book in book_list %}
+    <div class="container card bg-primary mt-3">
+        <div class="row justify-content-center">
+            <!-- Left hand column -->
+            <div class="col-lg-8 col-md-6 text-white bg-primary">
+                <h2 class="card-title text-white text-center">
+                    <a href="{% pageurl book %}" class="text-white">{{ book.book_title }}</a>
+                </h2>
                 <div class="card-body card-text text-white">
+                    {% if book.teaser %}
                     {{ book.teaser }}
+                    {% else %}
+                    {{ book.description|truncatewords:50}}
+                    {% endif %}
                 </div>
             </div>
-            <div class="col-lg-4 col-md-6 container-dark px-4">
+            <!-- Right hand column -->
+            <div class="col-lg-5 xl-6 text-center order-1 order-lg-2 mb-2">
                 {% image book.cover_image min-2000x400 as cover_image %}
-                <a href="{% pageurl book %}">
-                <img src="{{ cover_image.url }}" class="p-4 w-100"></a>
+                <img src="{{ cover_image.url }}" class="mw-100" style="max-height: 25vh">
             </div>
+        <!-- Close Row -->
         </div>
-        {% endfor %}
+    <!-- Close Card -->
     </div>
+    {% endfor %}
 </div>
-
 {% endblock %}

--- a/books/templates/books/books_index_page.html
+++ b/books/templates/books/books_index_page.html
@@ -3,6 +3,7 @@
 {% block body_class %}template-homepage{% endblock %}
 {% block content %}
 
+<!-- Render Top/Intro Block -->
 <div class="container-fluid container-dark py-5">
     <div class="container">
         <div class="row justify-content-center">
@@ -16,26 +17,33 @@
             </div>
         </div>
     </div>
+<!-- End Intro block, start iterating through book blocks -->
     {% for book in book_list %}
-    <div class="container card bg-primary mt-3">
+    <div class="container card bg-primary mt-4 mb-5 p-3">
         <div class="row justify-content-center">
             <!-- Left hand column -->
-            <div class="col-lg-8 col-md-6 text-white bg-primary">
-                <h2 class="card-title text-white text-center">
-                    <a href="{% pageurl book %}" class="text-white">{{ book.book_title }}</a>
+            <div class="col-12 col-md-8 align-items-center text-center order-2 order-md-1">
+                <h2 class="card-title text-white text-center my-2">
+                    <a href="{% pageurl book %}" class="orange-link">{{ book.book_title }}</a>
                 </h2>
-                <div class="card-body card-text text-white">
+                <p class="card-body card-text text-white my-2">
                     {% if book.teaser %}
-                    {{ book.teaser }}
+                    {{ book.teaser|richtext }}
                     {% else %}
-                    {{ book.description|truncatewords:50}}
+                    {{ book.description|richtext|truncatewords:100}}
                     {% endif %}
+                </p>
+                <div class="row justify-content-center mt-4 mb-2">
+                    <a class="btn btn-outline-warning p-2 newsletter-font text-uppercase" 
+                    href="{% pageurl book %}" role="button">Find out more</a>
                 </div>
             </div>
             <!-- Right hand column -->
-            <div class="col-lg-5 xl-6 text-center order-1 order-lg-2 mb-2">
+            <div class="col align-items-center text-center order-1 order-md-2">
                 {% image book.cover_image min-2000x400 as cover_image %}
-                <img src="{{ cover_image.url }}" class="mw-100" style="max-height: 25vh">
+                <a href="{% pageurl book%}">
+                    <img src="{{ cover_image.url }}" class="mw-100" style="max-height: 50vh">
+                </a>
             </div>
         <!-- Close Row -->
         </div>

--- a/readme.MD
+++ b/readme.MD
@@ -38,4 +38,4 @@ Boostrap theme link in environment
 - Add sample .env file
 - create success url/template
 - finish contact form model (header injection/ try except block)
-- remove series from this model - not used by this person.
+- remove series from this model - will not be used by client at this time.


### PR DESCRIPTION
Removed routable page mixin as will not be used by this client at this time.
Replaced serve method on BooksIndexPage to serve with different queryset passed to context (book_list) = BookPage.objects.live.sort_by(-sort_order). 
Added a second text book and trialed it, including moving sort order.
Finalized booklist template, including testing mobile responsiveness, and adding a truncate at 150 words for description if custom book teaser not used.